### PR TITLE
Remove unnecessary override of membership operator

### DIFF
--- a/invenio_client/__init__.py
+++ b/invenio_client/__init__.py
@@ -372,9 +372,6 @@ class Record(dict):
         else:
             return datafields
 
-    def __contains__(self, item):
-        return super(Record, self).__contains__(item)
-
     def __repr__(self):
         return "Record(" + dict.__repr__(self) + ")"
 


### PR DESCRIPTION
Redefinition is not necessary as it has the same behavior as the base
class.
