### PR TITLE
setup: licence statement fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
+        'License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)',
         'Operating System :: OS Independent',
         'Topic :: Utilities',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,23 @@
-# This file is part of Dictdiffer.
-#
+# This file is part of Invenio-Client.
 # Copyright (C) 2014 CERN.
 #
-# Dictdiffer is free software; you can redistribute it and/or modify
-# it under the terms of the MIT License; see LICENSE file for more
-# details.
+# Invenio-Client is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio-Client is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
 
 [tox]
 envlist = py26, py27, py33, py34


### PR DESCRIPTION
- Fixes licence classifier in `setup.py` that mistakenly read MIT
  instead of GPLv2+.
- Fixes licence statement in `tox.ini`.

Signed-off-by: Tibor Simko tibor.simko@cern.ch
